### PR TITLE
Add support for aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "exports": "./dist/index.js",
   "scripts": {
-    "build": "esbuild --bundle --minify --platform=node --external:typescript --external:typedoc src/index.ts --outfile=dist/index.js"
+    "build": "esbuild --bundle --minify --platform=node --external:typescript --external:typedoc src/index.ts --outfile=dist/index.js",
+    "prepare": "npm run build"
   },
   "files": [
     "dist"


### PR DESCRIPTION
@rafern 
Hi, I have had problems detecting type declarations in `index.d.ts` when it contains exports from other files.

So I propose minor changes to detect if a found symbol is an alias for another symbol and then get the original symbol to properly read its `SyntaxKind`.

Also `prepare` script in the `package.json` allows for installation from GitHub via npm directly.